### PR TITLE
activator-seed-template: Update to Finatra RC1 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 scala:
-  - 2.11.6
+  - 2.11.7
 
 jdk:
   - openjdk7

--- a/README.md
+++ b/README.md
@@ -3,10 +3,3 @@
 [![Build Status](https://secure.travis-ci.org/twitter/finatra-activator-seed.png?branch=master)](http://travis-ci.org/twitter/finatra-activator-seed?branch=master)
 
 A minimal [activator](https://www.typesafe.com/get-started) seed template for creating a Finatra application.
-
-#### Note:
-By default Finatra will run your external service on port `:8888` -- this also happens to be the same port the Activator UI uses. Therefore, in order to be able to correctly run your project inside the Activator UI start the Activator on a different port. E.g.,
-
-```
-activator -Dhttp.port=9090 ui
-```

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "com.example"
 
 version := "1.0.0-SNAPSHOT"
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.7"
 
 fork in run := true
 
@@ -17,21 +17,33 @@ resolvers ++= Seq(
   "Finatra Repo" at "http://twitter.github.com/finatra"
 )
 
+lazy val versions = new {
+  val finagle = "6.28.0"
+  val finatra = "2.0.0.RC1"
+  val logback = "1.0.13"
+  val mockito = "1.9.5"
+  val scalatest = "2.2.3"
+  val specs2 = "2.3.12"
+}
+
 libraryDependencies ++= Seq(
-  "com.twitter.finatra" %% "finatra-http" % "2.0.0.M2",
-  "com.twitter.finatra" %% "finatra-logback" % "2.0.0.M2",
+  "ch.qos.logback" % "logback-classic" % versions.logback,
+  "ch.qos.logback" % "logback-classic" % versions.logback % "test",
 
-  "com.twitter.finatra" %% "finatra-http" % "2.0.0.M2" % "test",
-  "com.twitter.inject" %% "inject-server" % "2.0.0.M2" % "test",
-  "com.twitter.inject" %% "inject-app" % "2.0.0.M2" % "test",
-  "com.twitter.inject" %% "inject-core" % "2.0.0.M2" % "test",
-  "com.twitter.inject" %% "inject-modules" % "2.0.0.M2" % "test",
-  "com.twitter.finatra" %% "finatra-http" % "2.0.0.M2" % "test" classifier "tests",
-  "com.twitter.inject" %% "inject-server" % "2.0.0.M2" % "test" classifier "tests",
-  "com.twitter.inject" %% "inject-app" % "2.0.0.M2" % "test" classifier "tests",
-  "com.twitter.inject" %% "inject-core" % "2.0.0.M2" % "test" classifier "tests",
-  "com.twitter.inject" %% "inject-modules" % "2.0.0.M2" % "test" classifier "tests",
+  "com.twitter.finatra" %% "finatra-http" % versions.finatra,
+  "com.twitter.finatra" %% "finatra-slf4j" % versions.finatra,
 
-  "org.mockito" % "mockito-core" % "1.9.5" % "test",
-  "org.scalatest" %% "scalatest" % "2.2.3" % "test",
-  "org.specs2" %% "specs2" % "2.3.12" % "test")
+  "com.twitter.finatra" %% "finatra-http" % versions.finatra % "test",
+  "com.twitter.inject" %% "inject-server" % versions.finatra % "test",
+  "com.twitter.inject" %% "inject-app" % versions.finatra % "test",
+  "com.twitter.inject" %% "inject-core" % versions.finatra % "test",
+  "com.twitter.inject" %% "inject-modules" % versions.finatra % "test",
+  "com.twitter.finatra" %% "finatra-http" % versions.finatra % "test" classifier "tests",
+  "com.twitter.inject" %% "inject-server" % versions.finatra % "test" classifier "tests",
+  "com.twitter.inject" %% "inject-app" % versions.finatra % "test" classifier "tests",
+  "com.twitter.inject" %% "inject-core" % versions.finatra % "test" classifier "tests",
+  "com.twitter.inject" %% "inject-modules" % versions.finatra % "test" classifier "tests",
+
+  "org.mockito" % "mockito-core" % versions.mockito % "test",
+  "org.scalatest" %% "scalatest" % versions.scalatest % "test",
+  "org.specs2" %% "specs2" % versions.specs2 % "test")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9

--- a/src/main/scala/com/example/ExampleServer.scala
+++ b/src/main/scala/com/example/ExampleServer.scala
@@ -1,17 +1,19 @@
 package com.example
 
-import com.twitter.finagle.http.{Response, Request}
+import com.twitter.finagle.httpx.{Response, Request}
 import com.twitter.finatra.http.HttpServer
 import com.twitter.finatra.http.filters.CommonFilters
 import com.twitter.finatra.http.routing.HttpRouter
 import com.twitter.finatra.logging.filter.{TraceIdMDCFilter, LoggingMDCFilter}
-import com.twitter.finatra.logging.modules.LogbackModule
+import com.twitter.finatra.logging.modules.Slf4jBridgeModule
 
 object ExampleServerMain extends ExampleServer
 
 class ExampleServer extends HttpServer {
 
-  override def modules = Seq(LogbackModule)
+  override def modules = Seq(Slf4jBridgeModule)
+
+  override def defaultFinatraHttpPort = ":9999"
 
   override def configureHttp(router: HttpRouter) {
     router

--- a/src/main/scala/com/example/PingController.scala
+++ b/src/main/scala/com/example/PingController.scala
@@ -1,6 +1,6 @@
 package com.example
 
-import com.twitter.finagle.http.Request
+import com.twitter.finagle.httpx.Request
 import com.twitter.finatra.http.Controller
 
 class PingController extends Controller {

--- a/src/test/scala/com/example/ExampleFeatureTest.scala
+++ b/src/test/scala/com/example/ExampleFeatureTest.scala
@@ -1,6 +1,6 @@
 package com.example
 
-import com.twitter.finagle.http.Status._
+import com.twitter.finagle.httpx.Status.Ok
 import com.twitter.finatra.http.test.EmbeddedHttpServer
 import com.twitter.inject.server.FeatureTest
 

--- a/tutorial/index.html
+++ b/tutorial/index.html
@@ -16,9 +16,8 @@
             <h2>Configuring your application</h2>
             <p>The <a href="#code/build.sbt" class="shortcut">build.sbt</a> contains the sbt build configuration; you'll want to edit
               at least the project name and version.</p>
-            <p>By default Finatra will run your external service on port :8888 -- this also happens to be the same port the Activator
-              UI uses. Therefore, in order to be able to correctly run your project inside the Activator UI, start the Activator on a different port. E.g.,
-              <pre>activator -Dhttp.port=9090 ui</pre>
+            <p>This example by default will run your external service on port :9999 -- you can override this by either changing the code in the
+              ExampleServer class or by passing a different value in the -http.port flag.
             </p>
         </div>
         <div>


### PR DESCRIPTION
Problem
The template is behind in releases of Finatra and Finagle

Solution
Update the template to the latest Finatra release built against the latest Finagle release (which includes the switch to finagle-httpx from finagle-http). The lastest Finatra release also includes a way to default the
http port programmatically so that we can set the port in code to not conflict with the Activator UI.

Result
An updated template that uses the latest code and doesn't require a user to start the Activator UI on a
different (other than default) port of :8888.
